### PR TITLE
Changed UID to use the Strava athlete ID and include all Raw Info

### DIFF
--- a/lib/omniauth/strategies/strava.rb
+++ b/lib/omniauth/strategies/strava.rb
@@ -31,7 +31,8 @@ module OmniAuth
         {
           recent_ride_totals: athlete['recent_ride_totals'],
           ytd_ride_totals: athlete['ytd_ride_totals'],
-          all_ride_totals: athlete['all_ride_totals']
+          all_ride_totals: athlete['all_ride_totals'],
+          raw_info: athlete
         }
       end
 


### PR DESCRIPTION
It seems standard to use the user id as the UID for omiauth.

Included all information in extra info hash. Suggest you remove the other items as well.

Nice work and Thanks :-)
